### PR TITLE
Changed behavior for html files served over gopher vs http

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -261,6 +261,7 @@ class GUI:
 
         if not response:
             # send error to screen
+            print('ERROR in execute address...')
             return False
 
 
@@ -402,10 +403,7 @@ class GUI:
                 if x['port'] and x['port'][0] != ':':
                     x['port'] = ':{}'.format(x['port'])
 
-                if x['type'] == 'h':
-                    link = 'gopher://{}/{}'.format(x['host'], x['resource'])
-                else:
-                    link = 'gopher://{}{}/{}{}'.format(x['host'], x['port'], x['type'], x['resource'])
+                link = 'gopher://{}{}/{}{}'.format(x['host'], x['port'], x['type'], x['resource'])
 
                 tag_name = 'link{}'.format(self.link_count)
                 callback = (lambda event, href=link, tag_name=tag_name: self.gotolink(event, href, tag_name))
@@ -481,7 +479,7 @@ class GUI:
 
 
     def send_to_screen(self, data, itemtype='1', clear=True):
-        if itemtype == '0':
+        if itemtype in ['0','h']:
             self.show_text(data)
         elif itemtype in ['1','3','7']:
             data = self.parser.parse_menu(data)


### PR DESCRIPTION
It came to my attention that some people may want to serve html files over gopher, rather than http. After much discussion with users on `circumlunar.space` the following was decided (and is reflected in this update):

1. If an 'h' type link has `URL:http://somesite.org` or the like as its resource then it should be sent to the default web browser

2. If an 'h' type link does not have the `URL:` prefix for its resource it is meant to be loaded over gopher. In which case it is dumped to the screen as text, rather than rendered. This is done so as to avoid having the application be tied to Lynx (one of the few browsers that will render an html served over gopher as html). Since Burrow does not have a rendering engine and I do not want users to HAVE to have lynx installed, this seemed the good route for now. 